### PR TITLE
 Fixed === warnings

### DIFF
--- a/src/components/markdown.js
+++ b/src/components/markdown.js
@@ -28,7 +28,7 @@ const Markdown = ({ data }) => {
         if (line.startsWith('#### ')) return <h4 className={styles["h4"]}>{line.slice(5)}</h4>
         if (line.startsWith('##### ')) return <h5 className={styles["h5"]}>{line.slice(5)}</h5>
 
-        if (line == "") return;
+        if (line === "") return;
 
         return <p className={styles["p"]}>{line}</p>;
 

--- a/src/templates/programPage.js
+++ b/src/templates/programPage.js
@@ -57,9 +57,9 @@ const Program = ({ pageContext }) => {
   return <Layout>
     {content.map(section => {
 
-        if (section.type == "banner") return <SectionBanner context={pageContext} section={section} />
-        if (section.type == "markdown") return <SectionMarkdown context={pageContext} section={section} />
-        if (section.type == "code") return <SectionCode context={pageContext} section={section} />
+        if (section.type === "banner") return <SectionBanner context={pageContext} section={section} />
+        if (section.type === "markdown") return <SectionMarkdown context={pageContext} section={section} />
+        if (section.type === "code") return <SectionCode context={pageContext} section={section} />
 
     })}
   </Layout> 


### PR DESCRIPTION
Just replaced all of the spots where there are double equals signs (==) with triple equal signs (===). If you want to know why we need this change just check out, [this article](https://www.freecodecamp.org/news/javascript-triple-equals-sign-vs-double-equals-sign-comparison-operators-explained-with-examples/).

#33 
