### PR TITLE
refactor: CSS from Our-Partners #66

### DIFF
--- a/src/pages/partnerships/index.js
+++ b/src/pages/partnerships/index.js
@@ -53,11 +53,9 @@ function MissionPage({location}) {
         </div>
       </section>
       <section>
-        <div className="max-w-6xl mx-auto pb-16 px-4 flex">
-          <div className="w-2/3">
+        <div class="mx-auto max-w-6xl pb-16 px-4">
             <h2 className="font-bold text-4xl mb-4" id="about">Our Partners</h2>
-            {partnerData.description?.map(text => <p className="mb-2 text-lg">{text}</p>)}
-          </div>
+            {partnerData.description?.map(text => <p className="text-lg mb-2 max-w-3xl">{text}</p>)}
         </div>
       </section>
       <section>


### PR DESCRIPTION
Hi Team,

I Tried to resolve the #66 by refactoring the paragraph section of 'Our Partners' page.

Here are some results:
360x740
![image](https://user-images.githubusercontent.com/36273680/222899774-eaace2a7-0166-4879-b046-2095d51244d7.png)

1474x628
![image](https://user-images.githubusercontent.com/36273680/222899099-bf29039c-ec69-4fca-874e-44dfe09a0c35.png)

If this is not the expected result, please let me know.